### PR TITLE
Bump tuple to allow more versions of quiver.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tuple
-version: 1.0.1
+version: 1.0.1+1
 authors:
 - Boris Kaul <localvoid@gmail.com>
 - Kwang Yul Seo <kwangyul.seo@gmail.com>
@@ -8,6 +8,6 @@ homepage: https://github.com/kseo/tuple
 environment:
   sdk: '>=1.6.0'
 dependencies:
-  quiver: '>=0.22.0 <0.23.0'
+  quiver: '>=0.22.0 <0.27.0'
 dev_dependencies:
   test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,6 @@ homepage: https://github.com/kseo/tuple
 environment:
   sdk: '>=1.6.0'
 dependencies:
-  quiver: '>=0.22.0 <0.27.0'
+  quiver: '>=0.22.0 <0.28.0'
 dev_dependencies:
   test: any


### PR DESCRIPTION
tuple only uses `hash*` methods from quiver. quiver's `hash*` methods have seen no breaking changes in the last few releases.

I'm making a guess with the version bump. Should it be `1.0.2`?