### PR TITLE
Use `=` to separate a named parameter from its default value

### DIFF
--- a/lib/src/tuple.dart
+++ b/lib/src/tuple.dart
@@ -38,7 +38,7 @@ class Tuple2<T1, T2> {
   ///
   /// The elements are in item order. The list is variable-length
   /// if [growable] is true.
-  List toList({bool growable: false}) =>
+  List toList({bool growable = false}) =>
       new List.from([item1, item2], growable: growable);
 
   @override
@@ -94,7 +94,7 @@ class Tuple3<T1, T2, T3> {
   ///
   /// The elements are in item order. The list is variable-length
   /// if [growable] is true.
-  List toList({bool growable: false}) =>
+  List toList({bool growable = false}) =>
       new List.from([item1, item2, item3], growable: growable);
 
   @override
@@ -159,7 +159,7 @@ class Tuple4<T1, T2, T3, T4> {
   ///
   /// The elements are in item order. The list is variable-length
   /// if [growable] is true.
-  List toList({bool growable: false}) =>
+  List toList({bool growable = false}) =>
       new List.from([item1, item2, item3, item4], growable: growable);
 
   @override
@@ -237,7 +237,7 @@ class Tuple5<T1, T2, T3, T4, T5> {
   ///
   /// The elements are in item order. The list is variable-length
   /// if [growable] is true.
-  List toList({bool growable: false}) =>
+  List toList({bool growable = false}) =>
       new List.from([item1, item2, item3, item4, item5], growable: growable);
 
   @override
@@ -336,7 +336,7 @@ class Tuple6<T1, T2, T3, T4, T5, T6> {
   ///
   /// The elements are in item order. The list is variable-length
   /// if [growable] is true.
-  List toList({bool growable: false}) =>
+  List toList({bool growable = false}) =>
       new List.from([item1, item2, item3, item4, item5, item6],
           growable: growable);
 


### PR DESCRIPTION
This fixes the health suggestions from pub.dartlang.org:

<img width="653" alt="Screenshot 2019-03-19 at 16 09 30" src="https://user-images.githubusercontent.com/189580/54622360-621f1c80-4a61-11e9-823c-2429b333b2d5.png">
